### PR TITLE
Prevent crash when find returns no files

### DIFF
--- a/lib/SMB/Client.pm
+++ b/lib/SMB/Client.pm
@@ -343,7 +343,7 @@ sub perform_tree_command ($$$@) {
 			file_pattern => $pattern,
 			fid => $fid,
 		);
-		my $files = $response && $response->is_success ? $response->files : undef;
+		my $files = $response && $response->is_success ? $response->files : [];
 		$self->process_request($connection, 'Close',
 			fid => $fid,
 		);

--- a/lib/SMB/Client.pm
+++ b/lib/SMB/Client.pm
@@ -343,11 +343,12 @@ sub perform_tree_command ($$$@) {
 			file_pattern => $pattern,
 			fid => $fid,
 		);
-		my $files = $response && $response->is_success ? $response->files : [];
+		my $files = $response && $response->is_success ? $response->files : undef;
 		$self->process_request($connection, 'Close',
 			fid => $fid,
 		);
 
+		return unless $files;
 		return wantarray ? @$files : $files;
 	} elsif ($command eq 'dnload') {
 		my $filename = shift // '';


### PR DESCRIPTION
Prevents "Can't use an undefined value as an ARRAY reference at /usr/local/share/perl/5.20.2/SMB/Client.pm line 305." when no files are found (although here it's not line 305) -- replaced undef with []