### PR TITLE
fix find command on folder that contains many files and format string for strftime

### DIFF
--- a/lib/SMB/File.pm
+++ b/lib/SMB/File.pm
@@ -148,7 +148,7 @@ sub is_directory ($) {
 
 sub time_to_string ($;$) {
 	my $time = shift;
-	my $format = shift || "%4Y-%2m-%2d %2H:%2M";
+	my $format = shift || "%Y-%m-%d %H:%M";
 
 	return strftime($format, localtime $time);
 }


### PR DESCRIPTION
Hello.

fix typo in the default strftime format string (for example: now `dir` command in `smb-client` return something like this `file    32 4Y-2m-2d 2H:2M`)

strftime does not support numbers in format [link](http://www.cplusplus.com/reference/ctime/strftime/)

Best Regards, Ilya Pavlov